### PR TITLE
Filter move

### DIFF
--- a/js/class/Bishop.js
+++ b/js/class/Bishop.js
@@ -6,20 +6,9 @@ export default class Bishop extends Pieces
     {
         super(imgBishop, color, "Bishop");
         this.emplacement = emplacement;
+        this.directions = [
+            [1, 1], [-1, -1], [1, -1], [-1, 1] 
+        ];
+        this.maxSteps = 7;
     }
-
-    // Déplacements du fou : uniquement en diagonale
-    checkMove(board)
-    {
-        const [row, col] = this.emplacement;
-        const moves = [];
-
-        // Diagonales
-        for (let i = 1; i < 8; i++) {
-            moves.push([row + i, col + i], [row - i, col - i], [row + i, col - i], [row - i, col + i]);
-        }
-
-        return this.filterValidMoves(moves, board);
-    }
-
 }

--- a/js/class/King.js
+++ b/js/class/King.js
@@ -6,22 +6,10 @@ export default class King extends Pieces
     {
         super(imgKing, color, "King");
         this.emplacement = emplacement;
-    }
-
-    // Déplacements du roi : 1 case dans toutes les directions
-    checkMove(board)
-    {
-        const [row, col] = this.emplacement;
-        const moves = [
-            [row + 1, col], [row - 1, col],
-            [row, col + 1], [row, col - 1],
-            [row + 1, col + 1], [row - 1, col - 1],
-            [row + 1, col - 1], [row - 1, col + 1]
+        this.directions = [
+            [1, 0], [-1, 0], [0, 1], [0, -1], 
+            [1, 1], [-1, -1], [1, -1], [-1, 1] 
         ];
-
-        // Modifier et utiliser filterValidMove
-       return this.filterValidMoves(moves, board);
+        this.maxSteps = 1; 
     }
-
-
 }

--- a/js/class/Knight.js
+++ b/js/class/Knight.js
@@ -6,18 +6,10 @@ export default class Knight extends Pieces
     {
         super(imgKnight, color, "Knight");
         this.emplacement = emplacement;
-    }
-
-    // Déplacement en L
-    checkMove(board)
-    {
-        const [row, col] = this.emplacement;
-        const moves = [
-            [row + 2, col + 1], [row + 2, col - 1], [row - 2, col + 1], [row - 2, col - 1],
-            [row + 1, col + 2], [row + 1, col - 2], [row - 1, col + 2], [row - 1, col - 2]
+        this.directions = [
+            [2, 1], [2, -1], [-2, 1], [-2, -1],
+            [1, 2], [1, -2], [-1, 2], [-1, -2]
         ];
-
-        return this.filterValidMoves(moves, board);
+        this.maxSteps = 1;
     }
-
 }

--- a/js/class/Pawn.js
+++ b/js/class/Pawn.js
@@ -8,6 +8,7 @@ export default  class Pawn extends Pieces
         this.emplacement = emplacement;
     }
 
+    // Cette fonction remplace la fonction générique car le comportement du pion est différent
     // Déplacements du pion : en fonction de la couleur, une case vers le haut ou le bas
     checkMove(board)
     {

--- a/js/class/Pieces.js
+++ b/js/class/Pieces.js
@@ -7,6 +7,8 @@ export default class Pieces
         this.image = image;//image de la pièce
         this.color = color;//couleur de la pièce
         this.type = type;//type de la pièce(rois, reine, ect...)
+        this.directions = []; // À remplir par chaque pièce
+        this.maxSteps = 0;    // Nombre maximal de cases à parcourir (selon la pièce)
     }
 
 
@@ -15,43 +17,45 @@ export default class Pieces
         this.emplacement=newEmplacement;
     }
 
-    // Filtrer les mouvements pour rester dans les limites du plateau
-    // ne pas aller sur la case d'un pion de sa couleur
-    // ne pas aller au dela d'un pion d'une autre couleur
-    filterValidMoves(moves, board) 
-    {
-        // Vérifier si y a un joueur
-        const validMoves = moves.filter(move => {
-            const row = move[0];
-            const col = move[1];
+    // Méthode générique de déplacement
+    checkMove(board) {
+        const [row, col] = this.emplacement;
+        const moves = [];
 
-            // Vérifie si la case est en dehors du tableau
-            if(row > 7 || col > 7 || row < 0 || col < 0)
-            {
-                return false;
-            }
+        // Parcours toutes les directions possibles
+        for (const [dx, dy] of this.directions) {
+            for (let step = 1; step <= this.maxSteps; step++) {
+                const newRow = row + step * dx;
+                const newCol = col + step * dy;
 
-            // Vérifie si la case de destination est vide (null) dans le plateau
-            if(board[row][col] != null)
-            {
-                // Vérifie si la case est un pion de sa couleur
-                if(board[row][col].color != this.color)
-                {
-                    return true;
+                // Vérifie si la case est en dehors du plateau
+                if (newRow < 0 || newRow > 7 || newCol < 0 || newCol > 7) break;
+
+                const targetPiece = board[newRow][newCol];
+
+                if (targetPiece === null) {
+                    // Case vide, ajoute le mouvement
+                    moves.push([newRow, newCol]);
+                } else {
+                    // Case occupée par une pièce
+                    if (targetPiece.color !== this.color) {
+                        // Capture possible, ajoute le mouvement
+                        moves.push([newRow, newCol]);
+                    }
+                    // Arrête le déplacement dans cette direction
+                    break;
                 }
-                else {
-                    return false
-                }
             }
-            else 
-            {
-                return board[row][col] === null;
-            }        
-        });
+        }
 
-        console.log(validMoves);
-
-        return validMoves;
+        return this.filterValidMoves(moves, board);
     }
 
+    // Méthode pour valider les mouvements
+    filterValidMoves(moves) {
+        return moves.filter(move => {
+            const [row, col] = move;
+            return row >= 0 && row <= 7 && col >= 0 && col <= 7;
+        });
+    }
 }

--- a/js/class/Queen.js
+++ b/js/class/Queen.js
@@ -7,9 +7,9 @@ export default class Queen extends Pieces
         super(imgQueen, color, "Queen");
         this.emplacement = emplacement;
         this.directions = [
-            [1, 0], [-1, 0], [0, 1], [0, -1],   // Lignes et colonnes
-            [1, 1], [-1, -1], [1, -1], [-1, 1]   // Diagonales
+            [1, 0], [-1, 0], [0, 1], [0, -1],   
+            [1, 1], [-1, -1], [1, -1], [-1, 1]   
         ];
-        this.maxSteps = 8; // La Reine peut se déplacer sur toute la longueur du plateau
+        this.maxSteps = 8; 
     }
 }

--- a/js/class/Queen.js
+++ b/js/class/Queen.js
@@ -6,22 +6,10 @@ export default class Queen extends Pieces
     {
         super(imgQueen, color, "Queen");
         this.emplacement = emplacement;
+        this.directions = [
+            [1, 0], [-1, 0], [0, 1], [0, -1],   // Lignes et colonnes
+            [1, 1], [-1, -1], [1, -1], [-1, 1]   // Diagonales
+        ];
+        this.maxSteps = 8; // La Reine peut se déplacer sur toute la longueur du plateau
     }
-
-    // Déplacements de la reine : toutes les cases dans toutes les directions
-    checkMove(board)
-    {
-        const [row, col] = this.emplacement;
-        const moves = [];
-
-        // Ligne verticale et horizontale
-        for (let i = 1; i < 8; i++) {
-            moves.push([row + i, col], [row - i, col], [row, col + i], [row, col - i]);
-            moves.push([row + i, col + i], [row - i, col - i], [row + i, col - i], [row - i, col + i]);
-
-        }
-
-        return this.filterValidMoves(moves, board);
-    }
-
 }

--- a/js/class/Rook.js
+++ b/js/class/Rook.js
@@ -6,21 +6,10 @@ export default  class Rook extends Pieces
     {
         super(imgRook, color, "Rook");
         this.emplacement = emplacement;
-    }
-
-    // Déplacements de la tour : uniquement sur les lignes et colonnes
-    checkMove(board)
-    {
-        const [row, col] = this.emplacement;
-        const moves = [];
-
-        // lignes verticales et horizontales
-        for (let i = 1; i < 8; i++) {
-            moves.push([row + i, col], [row - i, col], [row, col + i], [row, col - i]);
-        }
-    
-
-        return this.filterValidMoves(moves, board);
+        this.directions = [
+            [1, 0], [-1, 0], [0, 1], [0, -1]
+        ];
+        this.maxSteps = 7; 
     }
 
 }


### PR DESCRIPTION
Ajout d'une fonction générique pour filtrer les moves.
- Permet de ne pas manger ses alliés
- Ne pas pouvoir jouer derrière une pièce (sur la ligne / diagonale)

Fonction unique pour le pion qui possède un fonctionnement unique.